### PR TITLE
Feature: 55 configure python logging

### DIFF
--- a/app/src/team.py
+++ b/app/src/team.py
@@ -1,3 +1,4 @@
+import logging
 import random
 
 from statistics import mean
@@ -360,7 +361,8 @@ class Team:
             self.social_event()
 
     def integration_test(self, tq: TaskQueue, n=None):
-        print(n)
+        
+        logging.debug("Start integration test.")
         tasks = list(tq.get(done=True, unit_tested=True, integration_tested=False))[:n]
         for task in tasks:
             if task.correct_specification:
@@ -501,9 +503,9 @@ class ScrumTeam:
         
     def daily(self):
         if self.junior_master: 
-            print("Daily with junior")
+            pass
         elif self.senior_master:
-            print("Daily with senior")
+            pass
 
 
 

--- a/app/views/app.py
+++ b/app/views/app.py
@@ -1,6 +1,7 @@
 import logging
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
+from app.views.util import serving_log
 
 from mongo_models import MongoConnection, ScenarioMongoModel, UserMongoModel, ClickHistoryModel, MongoConnection
 
@@ -12,12 +13,13 @@ def connected(t):
 
 @login_required
 def app(request, sid):
-    logging.info(f"Served app.html for user {request.user.username}")
+    serving_log('app', request)
     return render(request, "app/app.html")
 
 
 @login_required
 def index(request):
+    serving_log('index', request)
     if not connected(500):
         return render(request, "app/dbfail.html")
     scenario_model = ScenarioMongoModel()

--- a/app/views/app.py
+++ b/app/views/app.py
@@ -1,3 +1,4 @@
+import logging
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 
@@ -11,6 +12,7 @@ def connected(t):
 
 @login_required
 def app(request, sid):
+    logging.info(f"Served app.html for user {request.user.username}")
     return render(request, "app/app.html")
 
 
@@ -24,7 +26,6 @@ def index(request):
     s_list = []
     for scenario in sc:
         user_score_rank = user_model.get_user_ranking(str(scenario.id)).get(request.user.username, {})
-        print(user_score_rank)
         best_score = user_score_rank.get('score', "-")
         rank = user_score_rank.get('rank', "-")
         tries = user_model.get_num_tries(user=request.user.username, template_id=str(scenario.id))

--- a/app/views/rest.py
+++ b/app/views/rest.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from os import read
 
 from django.contrib.auth.decorators import login_required
@@ -34,6 +35,7 @@ def end_scenario(s: UserScenario, username):
 @login_required
 @csrf_exempt
 def click_continue(request, sid):
+    logging.info(f"Continue simulation for user {request.user.username}")
     model = ScenarioMongoModel()
     s = model.get(sid)
     tasks_done_before = len(s.task_queue.get(done=True))
@@ -62,7 +64,7 @@ def click_continue(request, sid):
                 overtime = 0
 
             s.work(5, int(data['meetings']), training_hours, overtime, integration_test=integration_test, social=social_event)
-            print(s.task_queue)
+            logging.debug(f"Task Queue: {s.task_queue}")
         if s.counter >= 0:
             s.get_decision().eval(data)
         try:

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -1,3 +1,4 @@
+import logging
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
@@ -26,16 +27,17 @@ def login_request(request):
             user = authenticate(username=username, password=password)
             if user is not None:
                 login(request, user)
-                messages.info(request, f"You are now logged in as {username}.")
+                logging.info(f"Successful login user {username}.")
                 return redirect("/")
             else:
-                messages.error(request, "Invalid username or password.")
+                logging.error(f"Rejected login user {username}. Authentication failed.")
         else:
-            messages.error(request, "Invalid username or password.")
+            logging.error(f"Invalid login form.")
     form = AuthenticationForm()
     return render(request=request, template_name="app/login.html", context={"login_form": form})
 
 
 def logout_request(request):
     logout(request)
+    logging.info(f"Successful logout user {request.user.username}")
     return redirect('/')

--- a/app/views/util.py
+++ b/app/views/util.py
@@ -1,3 +1,4 @@
+import logging
 from app.src.scenario import UserScenario
 from app.src.team import ScrumTeam
 from utils import data_get, get_active_label
@@ -54,3 +55,7 @@ def set_model(s: UserScenario, model):
 
 def generate_object_id():
     pass
+
+
+def serving_log(page: str, request):
+    logging.info(f"Serving {page}.html for user {request.user.username}")

--- a/mongo_models.py
+++ b/mongo_models.py
@@ -199,7 +199,7 @@ class UserMongoModel(MongoConnection):
         output = None
         for i, score in enumerate(scores):
             if score['scenario_id'] == scenario_id:
-                logging.info(f"Deleteted {scenario_id} from user {user}'s scores.")
+                logging.debug(f"Deleteted {scenario_id} from user {user}'s scores.")
                 output = score
                 del scores[i]
                 break

--- a/mongo_models.py
+++ b/mongo_models.py
@@ -1,3 +1,4 @@
+import logging
 from time import time
 
 from bson.objectid import ObjectId
@@ -198,7 +199,7 @@ class UserMongoModel(MongoConnection):
         output = None
         for i, score in enumerate(scores):
             if score['scenario_id'] == scenario_id:
-                print("DELETED")
+                logging.info(f"Deleteted {scenario_id} from user {user}'s scores.")
                 output = score
                 del scores[i]
                 break

--- a/softDsim/settings.py
+++ b/softDsim/settings.py
@@ -27,12 +27,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 
-
-
 # Take environment variables from .env file
 env = environ.Env()
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
-
 
 
 SECRET_KEY = env('SECRET_KEY')
@@ -71,8 +68,7 @@ ROOT_URLCONF = 'softDsim.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates']
-        ,
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -97,8 +93,8 @@ DATABASES = {
         'NAME': configuration.database_name,
         'ENFORCE_SCHEMA': False,
         'CLIENT': {
-                'host': configuration.mongo_client
-            }  
+            'host': configuration.mongo_client
+        }
     }
 }
 
@@ -150,3 +146,27 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 #STATICFILES_DIRS = [BASE_DIR / "static"]
 
 LOGIN_URL = '/login'
+
+# Logging
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'stdlog': {
+            'format': '[{levelname} {asctime:s}] {message} ({filename}:{lineno})',
+            'style': '{',
+            'datefmt' : "%d.%m %H:%M:%S"
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'stdlog'
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+}

--- a/tests/test_api/test_api.py
+++ b/tests/test_api/test_api.py
@@ -58,10 +58,8 @@ def test_load_scenario(api_client: APIClient, user, decisions):
     assert response.url == f'/s/{usid}'
 
     response = api_client.get(f'/continue/{usid}')
-    print(response.json)
     assert response.status_code == 200
     response = api_client.get(f'/continue/{usid}')
-    print(response.json)
     assert response.status_code == 200
 
     us = mongo.get(usid)


### PR DESCRIPTION
Added basic logging settings ([python's standard logging lib](https://docs.python.org/3/library/logging.html#module-logging)), by adding the `LOGGING` parameter to [settings.py](https://github.com/antonroesler/softDsim/blob/develop/softDsim/settings.py). 

Also removed all `print()`statements that were left in the app. And added a few basic logging statements. From now on, at every point something *interesting* happens, we should use a logging statement: 
```python
import logging

# Basic levels we will use
logging.error(...)  # For Errors
logging.info(...)   # For basic informations
logging.debug(...)  # For small details, usefull infos for debugging
```

The current setting is set on `INFO` that means, error and info logs are displayed, debug logs are not displayed. This setting can be changed in softDsim/settings.py in LOGGING -> root -> level. 