### PR TITLE
Feature: #76 Added GET Scenario List Endpoint

### DIFF
--- a/app/api/scenario.py
+++ b/app/api/scenario.py
@@ -1,0 +1,15 @@
+from django.db import models
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+from rest_framework import status
+
+from mongo_models import ScenarioMongoModel
+
+
+@api_view(['GET'])
+def scenario(req):
+    scenario_list = ScenarioMongoModel().find_all_templates()
+    results = {str(s.id): s.name for s in scenario_list}
+    data = {'count': len(results), 'results': results}
+    return Response(data, status=status.HTTP_200_OK)
+

--- a/app/api_endpoints.py
+++ b/app/api_endpoints.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .api import endpoint_test
+from .api import endpoint_test, scenario
 
 urlpatterns = [
     path('test', endpoint_test.api_test, name='api_test'),
+    path('scenario', scenario.scenario, name="scenario")
 ]

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -1,0 +1,127 @@
+# API Reference
+
+## Authentifizierung
+
+```{warning}
+Bisher besteht keine Authentifizierung.
+```
+
+## API Testen
+
+Zum Testen der API wird [Postman](https://www.postman.com/) empfohlen.
+
+### Test Endpunkt GET
+
+Um zu testen ob der Server gestartet ist und auch erreichbar ist, gibt es den Test-Endpunkt.
+
+```{http:get} /api/test/
+Testen der API
+```
+
+```bash
+localhost:8000/api/test
+```
+
+**Example response**:
+
+Die Antwortet des Servers lautet wie folgt:
+
+```javascript
+{
+    "req": "GET",
+    "msg": "Hi from Django"
+}
+```
+
+### Test Endpunkt POST
+
+Genau so funktioniert der selbe Endpunkt auch für POST Requests
+
+```{http:post} /api/test/
+Testen der API
+```
+
+**Example response**:
+
+Die Antwortet des Servers lautet wie folgt:
+
+```javascript
+{
+    "req": "POST",
+    "msg": "Hi from Django"
+}
+```
+
+Alle anderen Methoden (abseits von GET und POST) sind vom Test-Endpunkt nicht unterstützt und führen, am Beispiel von DELETE,  zu folgender Response:
+
+```{http:delete} /api/test/
+Testen der API
+```
+
+**Example response**:
+
+```javascript
+{
+    "detail": "Method \"DELETE\" not allowed."
+}
+```
+
+## API Endpunkte (Resources)
+
+### Szenario Liste
+
+```{http:get} /api/scenario/
+Abfragen einer Liste mit allen Szenarios (ID und Name) in der Datenbank. Als Szenario sind hier Template Szenarios gemeint, nicht einzelne Nutzer-Szenarios.
+```
+
+**Example request**:
+
+```bash
+localhost:8000/api/scenario
+```
+
+**Example response**:
+
+```javascript
+{
+    "count": 2,
+    "results": {
+        '64abc': "Scenario Name",
+        '64abd': "Ein zweites Szenario",
+    }
+}
+```
+
+| Response Parameter | |
+|--------------------|-|
+|*int* **count** | Anzahl der Szenarios|
+|*object* **results**| json-Objekt mit einem Eintrag pro Szenario `'<id>':'<name>'`|
+
+### Szenario Details
+
+```{warning}
+Dieser Endpunkt ist WIP und steht derzeit nicht bereit
+```
+
+```{http:get} /api/scenario/(str:id)/
+Abfragen aller Informationen eines spezifischen Szenarios
+```
+
+**Example request**:
+
+```bash
+curl https://readthedocs.org/api/v2/project/?slug=pip
+```
+
+**Example response**:
+
+```javascript
+{
+
+}
+```
+
+| Response Parameter | |
+|--------------------|-|
+|*int* **count** | Anzahl der Szenarios|
+|*object* **results**| json-Objekt mit einem Eintrag pro scenario `'<id>':'<name>'`|

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,8 @@ release = '0.1'
 # ones.
 extensions = [
     'myst_parser',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinxcontrib.httpdomain'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Welcome to softDsim's documentation!
    :maxdepth: 1
 
    documentation/how_to.md
-
+   api/rest.md
 
 Indices and tables
 ==================

--- a/mongo_models.py
+++ b/mongo_models.py
@@ -1,5 +1,6 @@
 import logging
 from time import time
+from typing import List
 
 from bson.objectid import ObjectId
 from deprecated.classic import deprecated
@@ -129,7 +130,7 @@ class ScenarioMongoModel(MongoConnection):
             return self.collection.delete_many({"_id": a})
         raise NoObjectWithIdException()
 
-    def find_all_templates(self):
+    def find_all_templates(self) -> List[Scenario]:
         """Finds all scenarios (templates) in the database
 
         Returns:


### PR DESCRIPTION
### Szenario Liste

**GET** `api/scenario/`

Abfragen einer Liste mit allen Szenarios (ID und Name) in der Datenbank. Als Szenario sind hier Template Szenarios gemeint, nicht einzelne Nutzer-Szenarios.


**Example request**:

```bash
localhost:8000/api/scenario
```

**Example response**:

```javascript
{
    "count": 2,
    "results": {
        '64abc': "Scenario Name",
        '64abd': "Ein zweites Szenario",
    }
}
```

| Response Parameter | |
|--------------------|-|
|*int* **count** | Anzahl der Szenarios|
|*object* **results**| json-Objekt mit einem Eintrag pro Szenario `'<id>':'<name>'`|
