### PR TITLE
feature: #123 Added model for `SceanrioConfig`

### DIFF
--- a/app/api/views/scenario_config.py
+++ b/app/api/views/scenario_config.py
@@ -1,0 +1,62 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
+from rest_framework import status
+from django.shortcuts import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from app.serializers.scenario_config import ScenarioConfig, ScenarioConfigSerializer
+
+from app.models.scenario_config import ScenarioConfig
+
+
+@method_decorator(csrf_protect, name="dispatch")
+class ScenarioConfigView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request):
+        serializer = ScenarioConfigSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(
+                {"status": "success", "data": serializer.data},
+                status=status.HTTP_200_OK,
+            )
+        else:
+            print("Invalid")
+            return Response(
+                {"status": "error", "data": serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+    def get(self, request, id=None):
+        if id:
+            if str(id).isnumeric():
+                item = ScenarioConfig.objects.get(id=id)
+            else:
+                item = ScenarioConfig.objects.get(name=id)
+            serializer = ScenarioConfigSerializer(item)
+            return Response(
+                {"status": "success", "data": serializer.data},
+                status=status.HTTP_200_OK,
+            )
+
+        items = ScenarioConfig.objects.all()
+        serializer = ScenarioConfigSerializer(items, many=True)
+        return Response(
+            {"status": "success", "data": serializer.data}, status=status.HTTP_200_OK
+        )
+
+    def patch(self, request, id=None):
+        item = ScenarioConfig.objects.get(id=id)
+        serializer = ScenarioConfigSerializer(item, data=request.data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({"status": "success", "data": serializer.data})
+        else:
+            return Response({"status": "error", "data": serializer.errors})
+
+    def delete(self, request, id=None):
+        item = get_object_or_404(ScenarioConfig, id=id)
+        item.delete()
+        return Response({"status": "success", "data": "Item Deleted"})

--- a/app/api_endpoints.py
+++ b/app/api_endpoints.py
@@ -10,6 +10,7 @@ from .api.security.security_view import (
 )
 
 from app.api.views.team import SkillTypeView, TeamViews, MemberView
+from app.api.views.scenario_config import ScenarioConfigView
 
 # all request with /api/ land here (see softDsim/urls.py)
 urlpatterns = [
@@ -27,4 +28,6 @@ urlpatterns = [
     path("member/<int:id>", MemberView.as_view()),
     path("skill-type", SkillTypeView.as_view()),
     path("skill-type/<int:id>", SkillTypeView.as_view()),
+    path("scenario-config", ScenarioConfigView.as_view()),
+    path("scenario-config/<str:id>", ScenarioConfigView.as_view()),
 ]

--- a/app/models/scenario_config.py
+++ b/app/models/scenario_config.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+
+class ScenarioConfig(models.Model):
+    name = models.CharField(max_length=32, unique=True)
+    stress_error_optimum = models.FloatField(default=0.2)
+    stress_weekend_reduction = models.FloatField(default=-0.15)
+    stress_overtime_increase = models.FloatField(default=0.05)
+    stress_error_increase = models.FloatField(default=0.02)
+    task_completion_coefficient = models.FloatField(default=1.0)
+    error_completion_coefficient = models.FloatField(default=1.5)
+    done_tasks_per_meeting = models.IntegerField(default=50)
+    done_tasks_familiarity_factor = models.FloatField(default=10)
+    train_skill_increase_rate = models.FloatField(default=0.1)

--- a/app/serializers/scenario_config.py
+++ b/app/serializers/scenario_config.py
@@ -1,0 +1,8 @@
+from app.models.scenario_config import ScenarioConfig
+from rest_framework import serializers
+
+
+class ScenarioConfigSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ScenarioConfig
+        fields = "__all__"


### PR DESCRIPTION
A neat implementation

```
GET http://127.0.0.1:8000/api/scenario-config
````
Can be used to get a list of all ScenarioConfigs from DB: Currently empty:
```json
{
    "status": "success",
    "data": []
}
```
We can add a config, it will recieve ID 1

```
POST http://127.0.0.1:8000/api/scenario-config
```
Body: 
```json
{
    "name": "easy-conf",
    "train_skill_increase_rate": 0.1
}
````
POST must include a body with *at least* the `name` Attribute which must be unique, all other Attributes are optional and have default values as are shown below.

Now we can also GET a single config either by ID:

```
GET http://127.0.0.1:8000/api/scenario-config/1
````
or by using the name
```
GET http://127.0.0.1:8000/api/scenario-config/easy-conf
````
```json
{
    "status": "success",
    "data": {
        "id": 1,
        "name": "easy-conf",
        "stress_error_optimum": 0.2,
        "stress_weekend_reduction": -0.15,
        "stress_overtime_increase": 0.05,
        "stress_error_increase": 0.02,
        "task_completion_coefficient": 1.0,
        "error_completion_coefficient": 1.5,
        "done_tasks_per_meeting": 50,
        "done_tasks_familiarity_factor": 10.0,
        "train_skill_increase_rate": 0.1
    }
}
```
